### PR TITLE
Reset rooms

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "prestart": "npm run build",
     "start": "func start",
     "resetRooms": "tsx src/cli.ts resetRooms",
+    "resetRoom": "tsx src/cli.ts resetRoom",
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "deploy": "func azure functionapp publish roguelike-celebration-mud",
     "prestart": "npm run build",
     "start": "func start",
+    "resetRooms": "tsx src/cli.ts resetRooms",
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -1,0 +1,31 @@
+import DB from './redis'
+import { resetAllRooms } from './rooms'
+
+// TODO some sorta Yet Another Arg Parsing deal might be useful eventually
+
+const commands = {
+
+  async resetRooms() {
+    await resetAllRooms(console.log)
+  },
+
+}
+
+async function main(args = process.argv.slice(2)) {
+  if (!args.length) {
+    console.error('possible commands:', Object.keys(commands).sort())
+    return
+  }
+
+  const [arg, ...rest] = args
+  const cmd = commands[arg]
+  if (typeof cmd != 'function') {
+    console.error(`invalid command ${arg}`)
+    console.log('possible commands:', Object.keys(commands).sort())
+    return
+  }
+
+  await cmd(...rest)
+}
+
+main()

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -11,7 +11,7 @@ const commands = {
 
 }
 
-async function main(args = process.argv.slice(2)) {
+async function run(args: string[]) {
   if (!args.length) {
     console.error('possible commands:', Object.keys(commands).sort())
     return
@@ -26,6 +26,14 @@ async function main(args = process.argv.slice(2)) {
   }
 
   await cmd(...rest)
+}
+
+async function main(args = process.argv.slice(2)) {
+  try {
+    await run(args)
+  } finally {
+    DB.close()
+  }
 }
 
 main()

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -1,5 +1,5 @@
 import DB from './redis'
-import { resetAllRooms } from './rooms'
+import { resetRoom, resetAllRooms } from './rooms'
 
 // TODO some sorta Yet Another Arg Parsing deal might be useful eventually
 
@@ -7,6 +7,12 @@ const commands = {
 
   async resetRooms() {
     await resetAllRooms(console.log)
+  },
+
+  async resetRoom(...roomIds: string[]) {
+    for (const roomId of roomIds) {
+      await resetRoom(roomId, console.log)
+    }
   },
 
 }

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -127,7 +127,7 @@ interface Database {
   // -----------------------------------------------------------------
   // ROOM DATA
   // -----------------------------------------------------------------
-  setRoomData(room: Room)
+  setRoomData(room: Room): Promise<void>
   deleteRoomData(roomId: string): Promise<void>
   getRoomData(roomId: string): Promise<Room>
   getRoomIds(): Promise<string[]>

--- a/server/src/endpoints/resetRoomData.ts
+++ b/server/src/endpoints/resetRoomData.ts
@@ -1,15 +1,27 @@
 import { AuthenticatedEndpointFunction, LogFn } from '../endpoint'
-import { restAllRooms } from '../rooms'
+import { resetRoom, resetAllRooms } from '../rooms'
 import roomData from '../rooms/data/roomData.json'
 import { User } from '../user'
 
 const resetRoomData: AuthenticatedEndpointFunction = async (user: User, inputs: any, log: LogFn) => {
-  // TODO: Allow this to just wipe a specific room
-  await resetAllRooms()
-  return {
-    httpResponse: {
-      status: 200,
-      body: { roomData }
+  if (inputs.roomId) {
+    const { roomId } = inputs // TODO typeof ?== 'string'
+    await resetRoom(roomId)
+    return {
+      httpResponse: {
+        status: 200,
+        body: {
+          roomData: roomData[roomId]
+        }
+      }
+    }
+  } else {
+    await resetAllRooms()
+    return {
+      httpResponse: {
+        status: 200,
+        body: { roomData }
+      }
     }
   }
 }

--- a/server/src/endpoints/resetRoomData.ts
+++ b/server/src/endpoints/resetRoomData.ts
@@ -1,21 +1,11 @@
 import { AuthenticatedEndpointFunction, LogFn } from '../endpoint'
-import Redis from '../redis'
-import { Room } from '../rooms'
+import { restAllRooms } from '../rooms'
 import roomData from '../rooms/data/roomData.json'
 import { User } from '../user'
 
 const resetRoomData: AuthenticatedEndpointFunction = async (user: User, inputs: any, log: LogFn) => {
   // TODO: Allow this to just wipe a specific room
-
-  // First, delete all current rooms
-  const roomIds = await Redis.getRoomIds()
-  await Promise.all(roomIds.map(Redis.deleteRoomData))
-
-  // Then, add new data
-  await Promise.all(Object.values(roomData).map(room => {
-    return Redis.setRoomData(room as Room)
-  }))
-
+  await resetAllRooms()
   return {
     httpResponse: {
       status: 200,

--- a/server/src/rooms/index.ts
+++ b/server/src/rooms/index.ts
@@ -107,3 +107,19 @@ export async function resetAllRooms(
         .map(room => DB.setRoomData(room)))
   }
 }
+
+export async function resetRoom(
+  roomId: string,
+  log: (mess: string, ...extra: any[]) => void = null
+) {
+  const room = staticRoomData[roomId]
+  await DB.deleteRoomData(roomId)
+  if (log) log(`deleted room #${roomId}`)
+  if (room !== undefined) {
+    await DB.setRoomData(room)
+    if (log) {
+      const { id, ...info } = minimizeRoom(room)
+      log(`loaded room #${id}`, info)
+    }
+  }
+}

--- a/server/src/rooms/index.ts
+++ b/server/src/rooms/index.ts
@@ -82,3 +82,15 @@ export async function minimalRoomData (): Promise<{[roomId: string]: MinimalRoom
 
   return roomData
 }
+
+export async function resetAllRooms() {
+  // First, delete all current rooms
+  const roomIds = await DB.getRoomIds()
+  await Promise.all(
+    roomIds.map(DB.deleteRoomData))
+
+  // Then, add new data
+  await Promise.all(
+    Object.values(staticRoomData)
+      .map(room => DB.setRoomData(room)))
+}

--- a/server/src/rooms/index.ts
+++ b/server/src/rooms/index.ts
@@ -59,15 +59,16 @@ export interface MinimalRoom {
   displayName: string;
   shortName: string;
   hidden: boolean;
- }
+}
 
 function minimizeRoom (room: Room): MinimalRoom {
-  return {
-    id: room.id,
-    displayName: room.displayName,
-    shortName: room.shortName,
-    hidden: room.hidden
-  }
+  const {
+    id,
+    displayName,
+    shortName,
+    hidden = false
+  } = room
+  return { id, displayName, shortName, hidden }
 }
 
 export async function minimalRoomData (): Promise<{[roomId: string]: MinimalRoom}> {


### PR DESCRIPTION
- start a sever cli program to aid local admin/setup/etc
  - starting with a resetRooms and resetRoom command
- implement single room reset prior endpoint TODO
- simplified redis client config to be localhost-default, lessening the need for local dev server config
- [ ] TODO if we like this kind of zero config approach, can do similar for the frontend server url, postmark token, and simplify the local server docs

This PR is almost separable from the local-server work/branch itself, mostly overlapping around the new `dotenv` server dependency and related redis module changes.